### PR TITLE
Add Password Prompt for Admin on Account Verification

### DIFF
--- a/app/Http/Controllers/Resources/UserController.php
+++ b/app/Http/Controllers/Resources/UserController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Resources;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
 
 class UserController extends Controller
 {
@@ -29,11 +31,19 @@ class UserController extends Controller
         return view('admin.users.show', compact('user'));
     }
 
-    public function verifyUser(User $user)
+    public function verify(Request $request, User $user)
     {
-        $user->verified = true;
+        $request->validate([
+            'admin_password' => 'required|string',
+        ]);
+
+        if (!Hash::check($request->admin_password, Auth::user()->password)) {
+            return redirect()->back()->withErrors(['admin_password' => 'The password you entered is incorrect.']);
+        }
+
+        $user->verified = true; 
         $user->save();
 
-        return redirect()->route('admin.users.index')->with('success', 'User verified successfully');
+        return redirect()->route('admin.users.index')->with('success', 'User has been successfully verified.');
     }
 }

--- a/resources/views/Admin/users/show.blade.php
+++ b/resources/views/Admin/users/show.blade.php
@@ -76,13 +76,26 @@
                         <h5>Verify Service Provider</h5>
                     </div>
                     <div class="card-body">
-                        <form action="{{ route('admin.users.verify', $user) }}">
+                        <form action="{{ route('admin.users.verify', $user) }}" method="POST">
                             @csrf
-                            @method('PUT')
+                            @method('PATCH')
+
+                            <div class="form-group">
+                                <label for="admin_password">Enter Admin Password</label>
+                                <input type="password" id="admin_password" name="admin_password" class="form-control"
+                                    required>
+                            </div>
+
+                            @if ($errors->has('admin_password'))
+                                <div class="alert alert-danger">
+                                    {{ $errors->first('admin_password') }}
+                                </div>
+                            @endif
+
                             <button type="submit" class="btn btn-primary">Verify</button>
                         </form>
                     </div>
-                </div>
+
             @endif
         @endif
         <a href="{{ route('admin.users.index') }}" class="btn btn-secondary">Back</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,7 +50,7 @@ Route::prefix('admin')
     ->group(function () {
         Route::get('dashboard', [AdminDashboardController::class, 'getData'])
             ->name('dashboard');
-        Route::get('users/verify/{user}', [UserController::class, 'verifyUser'])->name('users.verify');
+        Route::patch('users/verify/{user}', [UserController::class, 'verify'])->name('users.verify');
         Route::resource('users', UserController::class);
     });
 


### PR DESCRIPTION
# Feature: Add admin password Prompt

## Description
Added an input for the admin to enter the password first before verifying the account

## Changes Made

- change http verbs used in verifying the user account.
- add input in for admin password
- refactor verify method in users controller to handle validation process.

## Purpose

to make verification process more authentic

## Related Issues

This pull request addresses the feature described in #
## Proof Changes are working
![image](https://github.com/user-attachments/assets/89b6aed6-7c4f-4f0e-8837-37d548423915)
### with a wrong password
![image](https://github.com/user-attachments/assets/b0df1b57-a30b-47cb-90e6-d442758cce85)