### PR TITLE
Filter Services by Verified Users

### DIFF
--- a/app/Http/Controllers/Resources/ServiceController.php
+++ b/app/Http/Controllers/Resources/ServiceController.php
@@ -21,12 +21,15 @@ class ServiceController extends Controller
         if (auth()->check() && auth()->user()->is_blocked) {
             $services = collect();  // No services shown to blocked user
         } else {
-            $services = EventService::with('user')->get();
+            $services = EventService::with('users')
+                ->whereHas('users', function ($query) {
+                    $query->where('verified', true);
+                })
+                ->get();
         }
 
         return view('client.service.index', compact('services'));
     }
-
 
     /**
      * Show the form for creating a new resource.

--- a/app/Models/EventService.php
+++ b/app/Models/EventService.php
@@ -34,4 +34,9 @@ class EventService extends Model
     {
         return $this->belongsTo(User::class, 'user_id'); // Replace 'user_id' with the correct foreign key
     }
+
+    public function users()
+    {
+        return $this->belongsTo(User::class, 'service_provider_id'); // Replace 'user_id' with the correct foreign key
+    }
 }


### PR DESCRIPTION

This pull request updates the ServiceController to fetch only those services associated with verified users. The changes include:

Adding a condition to the index method to filter services based on the is_verified status of the associated user.
Ensuring that blocked users see an empty collection of services.

Changes:

Updated ServiceController.php to include the whereHas condition for verified users.

Testing:
Verified that blocked users see no services.
Verified that only services associated with verified users are displayed.